### PR TITLE
docs: fix repo name in docker instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Use available images on Docker Hub:
 
 ```
 # latest stable release
-$ docker run --rm redis/memtier_benchmark:latest --help
+$ docker run --rm redislab/memtier_benchmark:latest --help
 
 # master branch edge build
-$ docker run --rm redis/memtier_benchmark:edge --help
+$ docker run --rm redislab/memtier_benchmark:edge --help
 ```
 
 Or, build locally:

--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ Use available images on Docker Hub:
 
 ```
 # latest stable release
-$ docker run --rm redislab/memtier_benchmark:latest --help
+$ docker run --rm redislabs/memtier_benchmark:latest --help
 
 # master branch edge build
-$ docker run --rm redislab/memtier_benchmark:edge --help
+$ docker run --rm redislabs/memtier_benchmark:edge --help
 ```
 
 Or, build locally:


### PR DESCRIPTION
Following through the README I realized that the Docker usage examples where pointing to the wrong repository. This PR updates said examples to use the correct repository name.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only change to Docker example commands; no code or deployment behavior is affected.
> 
> **Overview**
> Updates the **Using Docker** examples in `README.md` so `docker run` pulls from **`redislabs/memtier_benchmark`** instead of **`redis/memtier_benchmark`**, for both the **`latest`** and **`edge`** tags.
> 
> No runtime, build, or workflow changes—documentation only so copy-paste Docker commands match the published Hub repository.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45630fa72b2954cac2d49dc63b74a81773532933. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->