### PR TITLE
Stagger rate-limited client refills

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,12 +80,15 @@ memtier_benchmark_LDADD = \
 # layer + hdr_histogram (a leaf dep). No $(LIBEVENT_CFLAGS) by design (hygiene
 # only; purity is enforced by the S10 grep audit). -I$(srcdir) is required for
 # VPATH builds.
-check_PROGRAMS = prometheus_metrics_test
+check_PROGRAMS = prometheus_metrics_test rate_limiter_test
 prometheus_metrics_test_SOURCES = tests/unit/prometheus_metrics_test.cpp \
     prometheus_metrics.cpp prometheus_metrics.h \
     deps/hdr_histogram/hdr_histogram.c deps/hdr_histogram/hdr_histogram.h
 prometheus_metrics_test_CPPFLAGS = -I$(srcdir)
 prometheus_metrics_test_CXXFLAGS = -std=c++11 -Wall -Werror=vla -g
+rate_limiter_test_SOURCES = tests/unit/rate_limiter_test.cpp rate_limiter.h
+rate_limiter_test_CPPFLAGS = -I$(srcdir)
+rate_limiter_test_CXXFLAGS = -std=c++11 -Wall -Werror=vla -g
 TESTS = $(check_PROGRAMS)
 
 @CODE_COVERAGE_RULES@

--- a/client.cpp
+++ b/client.cpp
@@ -52,6 +52,7 @@
 #include "client.h"
 #include "cluster_client.h"
 #include "config_types.h"
+#include "rate_limiter.h"
 #include "retry_policy.h"
 
 
@@ -76,10 +77,13 @@ bool client::setup_client(benchmark_config *config, abstract_protocol *protocol,
 {
     m_config = config;
     assert(m_config != NULL);
-    unsigned long long total_num_of_clients = config->clients * config->threads;
+    unsigned long long total_num_of_clients = static_cast<unsigned long long>(config->clients) * config->threads;
+    m_request_rate_phase_microsecond =
+        calculate_rate_limit_phase(config->request_interval_microsecond, config->next_client_idx, total_num_of_clients);
 
     // create main connection
-    shard_connection *conn = new shard_connection(m_connections.size(), this, m_config, m_event_base, protocol);
+    shard_connection *conn = new shard_connection(m_connections.size(), this, m_config, m_event_base, protocol,
+                                                  m_request_rate_phase_microsecond);
     m_connections.push_back(conn);
 
     m_obj_gen = objgen->clone();
@@ -175,7 +179,8 @@ client::client(client_group *group) :
         m_scan_cursor("0"),
         m_scan_iteration_count(0),
         m_mget_defer(false),
-        m_arbitrary_needs_elem_tracking(false)
+        m_arbitrary_needs_elem_tracking(false),
+        m_request_rate_phase_microsecond(0)
 {
     m_event_base = group->get_event_base();
 
@@ -211,7 +216,8 @@ client::client(struct event_base *event_base, benchmark_config *config, abstract
         m_scan_iteration_count(0),
         m_keylist(NULL),
         m_mget_defer(false),
-        m_arbitrary_needs_elem_tracking(false)
+        m_arbitrary_needs_elem_tracking(false),
+        m_request_rate_phase_microsecond(0)
 {
     m_event_base = event_base;
 

--- a/client.h
+++ b/client.h
@@ -122,6 +122,11 @@ protected:
     // freshly cloned protocols would otherwise start with the flag cleared.
     bool m_arbitrary_needs_elem_tracking;
 
+    // Offset this logical client's rate-limit refill timer within one interval.
+    // All shard connections owned by the client share the same command stream
+    // and therefore the same phase.
+    unsigned int m_request_rate_phase_microsecond;
+
     // Apply the resolved arbitrary-command tracking flags to a single protocol.
     // Currently a single flag (set_track_elem_misses); plural name is
     // deliberate so additional per-protocol arbitrary-command setup can be

--- a/cluster_client.cpp
+++ b/cluster_client.cpp
@@ -240,7 +240,8 @@ void cluster_client::disconnect(void)
 
 shard_connection *cluster_client::create_shard_connection(abstract_protocol *abs_protocol)
 {
-    shard_connection *sc = new shard_connection(m_connections.size(), this, m_config, m_event_base, abs_protocol);
+    shard_connection *sc = new shard_connection(m_connections.size(), this, m_config, m_event_base, abs_protocol,
+                                                m_request_rate_phase_microsecond);
     assert(sc != NULL);
 
     // The shard_connection ctor clones abs_protocol, and clone() resets runtime

--- a/rate_limiter.h
+++ b/rate_limiter.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2011-2026 Redis Labs Ltd.
+ *
+ * This file is part of memtier_benchmark.
+ *
+ * memtier_benchmark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * memtier_benchmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MEMTIER_BENCHMARK_RATE_LIMITER_H
+#define MEMTIER_BENCHMARK_RATE_LIMITER_H
+
+#include <stdint.h>
+
+// Spread logical clients evenly over one refill interval. Multiplication is
+// widened before division because both inputs originate in 32-bit CLI fields.
+static inline unsigned int calculate_rate_limit_phase(unsigned int interval_microseconds,
+                                                      unsigned long long client_index, unsigned long long total_clients)
+{
+    if (interval_microseconds == 0 || total_clients == 0) return 0;
+    client_index %= total_clients;
+    return static_cast<unsigned int>((static_cast<uint64_t>(interval_microseconds) * client_index) / total_clients);
+}
+
+#endif // MEMTIER_BENCHMARK_RATE_LIMITER_H

--- a/shard_connection.cpp
+++ b/shard_connection.cpp
@@ -213,13 +213,16 @@ verify_request::~verify_request(void)
 }
 
 shard_connection::shard_connection(unsigned int id, connections_manager *conns_man, benchmark_config *config,
-                                   struct event_base *event_base, abstract_protocol *abs_protocol) :
+                                   struct event_base *event_base, abstract_protocol *abs_protocol,
+                                   unsigned int request_rate_phase_microsecond) :
         m_address(NULL),
         m_port(NULL),
         m_unix_sockaddr(NULL),
         m_bev(NULL),
         m_event_timer(NULL),
         m_request_per_cur_interval(0),
+        m_request_rate_phase_microsecond(request_rate_phase_microsecond),
+        m_request_rate_phase_pending(request_rate_phase_microsecond > 0),
         m_pending_resp(0),
         m_last_pushed_req_type(-1),
         m_connection_state(conn_disconnected),
@@ -1436,7 +1439,12 @@ void shard_connection::handle_event(short events)
 
         /* Set timer for request rate (create or recreate after reconnect) */
         if (m_config->request_rate && m_event_timer == NULL) {
-            struct timeval interval = {0, (int) m_config->request_interval_microsecond};
+            unsigned int first_interval_microsecond = m_config->request_interval_microsecond;
+            if (m_request_rate_phase_pending) {
+                first_interval_microsecond += m_request_rate_phase_microsecond;
+            }
+            struct timeval interval = {(time_t) (first_interval_microsecond / 1000000U),
+                                       (suseconds_t) (first_interval_microsecond % 1000000U)};
             m_request_per_cur_interval = m_config->request_per_interval;
             m_event_timer = event_new(m_event_base, -1, EV_PERSIST, cluster_client_timer_handler, (void *) this);
             event_add(m_event_timer, &interval);
@@ -1486,6 +1494,16 @@ void shard_connection::handle_event(short events)
 
 void shard_connection::handle_timer_event(void)
 {
+    // The first timeout includes this connection's phase. Switch to the common
+    // refill interval after it fires so the phase remains stable thereafter.
+    if (m_request_rate_phase_pending) {
+        struct timeval interval = {(time_t) (m_config->request_interval_microsecond / 1000000U),
+                                   (suseconds_t) (m_config->request_interval_microsecond % 1000000U)};
+        m_request_rate_phase_pending = false;
+        event_del(m_event_timer);
+        event_add(m_event_timer, &interval);
+    }
+
     m_request_per_cur_interval = m_config->request_per_interval;
 
     if (m_conns_manager->finished() && m_conns_manager->all_connections_idle()) {

--- a/shard_connection.h
+++ b/shard_connection.h
@@ -145,7 +145,8 @@ class shard_connection
 
 public:
     shard_connection(unsigned int id, connections_manager *conn_man, benchmark_config *config,
-                     struct event_base *event_base, abstract_protocol *abs_protocol);
+                     struct event_base *event_base, abstract_protocol *abs_protocol,
+                     unsigned int request_rate_phase_microsecond = 0);
     ~shard_connection();
 
     void set_address_port(const char *address, const char *port);
@@ -338,6 +339,8 @@ private:
     abstract_protocol *m_protocol;
     std::queue<request *> *m_pipeline;
     unsigned int m_request_per_cur_interval; // number requests to send during the current interval
+    unsigned int m_request_rate_phase_microsecond;
+    bool m_request_rate_phase_pending;
 
     // Pending-response counter. Mutated only by the connection's owning worker
     // thread (push_req/pop_req on the libevent callback) but read from the

--- a/tests/unit/rate_limiter_test.cpp
+++ b/tests/unit/rate_limiter_test.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2011-2026 Redis Labs Ltd.
+ *
+ * This file is part of memtier_benchmark.
+ *
+ * memtier_benchmark is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 2.
+ *
+ * memtier_benchmark is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with memtier_benchmark.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdio.h>
+
+#include "rate_limiter.h"
+
+static int failures = 0;
+
+#define CHECK_EQ(actual, expected)                                                                                     \
+    do {                                                                                                               \
+        unsigned int value = (actual);                                                                                 \
+        if (value != (expected)) {                                                                                     \
+            fprintf(stderr, "FAIL [%s:%d] got %u, expected %u\n", __FILE__, __LINE__, value, (expected));              \
+            failures++;                                                                                                \
+        }                                                                                                              \
+    } while (0)
+
+int main(void)
+{
+    CHECK_EQ(calculate_rate_limit_phase(0, 3, 4), 0U);
+    CHECK_EQ(calculate_rate_limit_phase(20000, 3, 0), 0U);
+
+    CHECK_EQ(calculate_rate_limit_phase(20000, 0, 4), 0U);
+    CHECK_EQ(calculate_rate_limit_phase(20000, 1, 4), 5000U);
+    CHECK_EQ(calculate_rate_limit_phase(20000, 2, 4), 10000U);
+    CHECK_EQ(calculate_rate_limit_phase(20000, 3, 4), 15000U);
+    CHECK_EQ(calculate_rate_limit_phase(20000, 5, 4), 5000U);
+
+    CHECK_EQ(calculate_rate_limit_phase(20000, 79, 80), 19750U);
+    CHECK_EQ(calculate_rate_limit_phase(1000000, 3999999999ULL, 4000000000ULL), 999999U);
+
+    if (failures != 0) {
+        fprintf(stderr, "%d rate limiter test(s) failed\n", failures);
+        return 1;
+    }
+
+    printf("rate limiter phase tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- spread rate-limited clients evenly across the existing refill interval
- use the per-client phase only for the first timer, then preserve the existing refill cadence
- apply the same logical-client phase to cluster shard connections
- add unit coverage for phase calculation, including wraparound and overflow-sensitive inputs

## Problem

Rate limiting currently gives every connection its full quota immediately and arms every refill timer with the same interval. Connections prepared together therefore refill together.

For example, 80 connections at 1,250 requests/sec each receive 25 requests every 20 ms. In steady state that can arrive as 2,000-request bursts every 20 ms even though the reported aggregate rate is exactly 100k requests/sec. The resulting server-side queueing makes latency percentiles describe the benchmark client's synchronized burst pattern as much as the server.

## Implementation

Each logical client gets a deterministic phase:

```
phase = refill_interval * client_index / total_clients
```

The first timer fires after `refill_interval + phase`. In that callback the persistent event is re-armed with the original refill interval, preserving both the configured request rate and the existing steady-state quota behavior.

A single client has phase zero and follows the original path. On reconnect, a phase that has not fired yet is retried; after initialization, reconnects resume the ordinary interval without adding another phase delay.

## Validation

Commands:

```
make format-check
make
make check
```

All pass, including the new `rate_limiter_test`.

Paired Redis 8.10.1 GET benchmark, 30 seconds, 8 threads, 10 connections/thread, pipeline 1, 128-byte values, `--rate-limiting=1250` per connection:

| metric | baseline | this PR | change |
|---|---:|---:|---:|
| throughput | 99,994 QPS | 99,954 QPS | -0.04% |
| average latency | 0.461 ms | 0.053 ms | -88.5% |
| p99 | 0.967 ms | 0.199 ms | -79.4% |
| p99.9 | 1.295 ms | 0.367 ms | -71.7% |
| p99.99 | 1.799 ms | 0.551 ms | -69.4% |
| client CPU | 1.135 cores | 0.917 cores | -19.2% |

A one-client check remained at the requested rate: 1,250.05 QPS before and 1,249.98 QPS after.

For comparison, current Valkey `valkey-benchmark --rps 100000` against the same Redis instance produced 99,738 QPS and a p99.99 between 0.527 and 0.575 ms. This PR reaches the same tail-latency range without replacing memtier's low-overhead quota/refill design.

I also tested increasing refill frequency to 250 Hz. It regressed p99.99 to 1.143 ms because sub-millisecond phases coalesced in the event loop. Interleaving phases within every worker improved p99.99 slightly to 0.527 ms but raised client CPU to 1.471 cores, so neither higher-overhead variant is included here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core request-timing and refill behavior for rate-limited runs; incorrect phase math could skew throughput or burst patterns, but scope is isolated and covered by new unit tests.
> 
> **Overview**
> Rate-limited logical clients no longer arm identical refill timers, which previously synchronized bursts across connections. Each client gets a deterministic phase via `calculate_rate_limit_phase` in **`rate_limiter.h`** (`interval × client_index / total_clients`), stored on **`client`** and passed into every **`shard_connection`** (including cluster shard connections created later).
> 
> **`shard_connection`** delays only the **first** libevent timer by `refill_interval + phase`, then re-arms the persistent timer with the normal interval in `handle_timer_event` so aggregate QPS and per-interval quotas stay the same while refills are spread across the window. Reconnect retries an unused phase once; after steady state, reconnect uses the ordinary interval.
> 
> Adds **`rate_limiter_test`** to `make check` with unit tests for edge cases (zero interval/clients, wraparound, wide multiplication).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909f8204611a321964388ac40afa41ef3b9d5fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->