### PR TITLE
feat(ci): allow manual workflow_dispatch for review/triage bots

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -19,10 +19,23 @@ name: Claude Automated Issue Triage
 # "model never directly posts" and "hard secret-scan gate" design does).
 # Never set `show_full_output: true`; never enable `ACTIONS_STEP_DEBUG` on
 # this workflow.
+#
+# `workflow_dispatch` lets a maintainer manually run this against an
+# already-open issue (e.g. one opened before this workflow existed) --
+# `gh workflow run claude-issue-triage.yml -f issue_number=123 --repo redis/memtier_benchmark`.
+# Requires repo write access to invoke, so the anonymous-trigger concern
+# doesn't apply here -- but the issue *content* is still attacker-controlled
+# text, so every mitigation below still applies the same way either trigger.
 
 on:
   issues:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -31,10 +44,15 @@ permissions:
 
 jobs:
   claude-triage:
-    # Skip the repo's own maintainers/members -- see header comment.
-    if: github.event.issue.author_association != 'OWNER' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'COLLABORATOR'
+    # Skip the repo's own maintainers/members on the automatic trigger -- see
+    # header comment. Doesn't apply to a manual workflow_dispatch -- a
+    # maintainer explicitly asking for triage on a specific issue number is
+    # an intentional override.
+    if: github.event_name == 'workflow_dispatch' || (github.event.issue.author_association != 'OWNER' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'COLLABORATOR')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      ISSUE_NUMBER: ${{ github.event.inputs.issue_number || github.event.issue.number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -51,7 +69,7 @@ jobs:
 
           prompt: |
             REPO: ${{ github.repository }}
-            ISSUE NUMBER: ${{ github.event.issue.number }}
+            ISSUE NUMBER: ${{ env.ISSUE_NUMBER }}
 
             Read this newly-opened issue's title and body via `gh issue view`.
 
@@ -111,7 +129,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -32,8 +32,9 @@ name: Claude Automated PR Review
 #     through a deterministic secret-pattern grep as a hard gate (not just a
 #     prompt instruction), writes it to a file, and posts via
 #     `--body-file` (never shell-interpolated) to the PR number taken from
-#     `github.event.pull_request.number` -- i.e. the workflow, not the model,
-#     decides which PR gets commented on and whether posting happens at all.
+#     the workflow's own trigger context (`$PR_NUMBER`, computed once at job
+#     level -- see below) -- i.e. the workflow, not the model, decides which
+#     PR gets commented on and whether posting happens at all.
 #   - `permissions` grants no `contents: write` -- this workflow can comment,
 #     it cannot push code, merge, or approve/dismiss reviews (those `gh pr`
 #     subcommands are also outside the read-only allowlist).
@@ -48,10 +49,25 @@ name: Claude Automated PR Review
 # from the outside -- the fork-based dry run in the rollout plan should
 # include one deliberate prompt-injection attempt before this is trusted
 # against real traffic.
+#
+# `workflow_dispatch` lets a maintainer manually run this against an
+# already-open PR (e.g. one opened before this workflow existed) --
+# `gh workflow run claude-pr-review.yml -f pr_number=123 --repo redis/memtier_benchmark`.
+# workflow_dispatch itself already requires repo write access to invoke, so
+# the "anonymous external author implicitly triggers a privileged run"
+# concern doesn't apply to this path -- but the PR *content* being reviewed
+# is still attacker-controlled text, so every mitigation above still applies
+# exactly the same way regardless of how the run was triggered.
 
 on:
   pull_request_target:
     types: [opened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
 
 permissions:
   contents: read
@@ -59,12 +75,16 @@ permissions:
 
 jobs:
   claude-review:
-    # Skip bot-authored PRs (e.g. Dependabot) -- real maintainer history on
-    # this repo shows no substantive engagement with these; an AI review
-    # comment here is pure noise, not a courtesy.
-    if: github.event.pull_request.user.type != 'Bot'
+    # Skip bot-authored PRs (e.g. Dependabot) on the automatic trigger -- real
+    # maintainer history on this repo shows no substantive engagement with
+    # these, an AI review comment here is pure noise, not a courtesy. Doesn't
+    # apply to a manual workflow_dispatch -- a maintainer explicitly asking
+    # for a review of a specific PR number is an intentional override.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
     steps:
       - name: Checkout base branch only (never the untrusted PR head)
         uses: actions/checkout@v6
@@ -81,7 +101,7 @@ jobs:
 
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ env.PR_NUMBER }}
 
             Use the memtier-maintainer-review skill (.claude/skills/memtier-maintainer-review/)
             to review this pull request in the authentic voice and standards of this
@@ -144,7 +164,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STRUCTURED_OUTPUT: ${{ steps.claude.outputs.structured_output }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Small follow-up to #520. Both Claude automation workflows only fire on
`opened`, so there was no way to point them at PRs/issues already open
before they existed. This adds `workflow_dispatch` support:

```
gh workflow run claude-pr-review.yml -f pr_number=123 --repo redis/memtier_benchmark
gh workflow run claude-issue-triage.yml -f issue_number=123 --repo redis/memtier_benchmark
```

`workflow_dispatch` already requires repo write access to invoke, so the
"anonymous author implicitly triggers a privileged run" concern the
`pull_request_target` design in #520 exists to guard against doesn't apply
to this path. But the PR/issue **content** being reviewed is still
attacker-controlled text regardless of who triggered the run, so every
existing mitigation from #520 applies exactly the same way: the Claude step
stays read-only and returns structured JSON instead of posting directly, a
separate plain-shell step runs a deterministic secret-pattern gate before
posting, and the target number is taken from the workflow's own computed
`PR_NUMBER`/`ISSUE_NUMBER` (input on manual dispatch, event context
otherwise) rather than anything the model could redirect.

The bot-author / maintainer-author skip conditions on the automatic trigger
are bypassed for manual dispatch, since a maintainer explicitly naming a
PR/issue number is itself the intentional signal to review it — those
guards exist to avoid noise on the *unconditional* auto-trigger, not to
second-guess a deliberate manual request.

Already exercised the underlying review logic manually (via the skill
directly, before this workflow_dispatch path existed) against three real
open PRs — #517, #518, #519 — with comments posted; this PR just wires up
the same thing to run through the actual workflow on demand instead of me
doing it by hand.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CI triggers only; the existing read-only model step, structured output, and deterministic secret scan before posting are unchanged.
> 
> **Overview**
> Both Claude automation workflows previously ran only on **issues/PRs opened**, so there was no way to triage or review items that were already open. This PR adds **`workflow_dispatch`** with required **`issue_number`** / **`pr_number`** inputs and documents the `gh workflow run …` invocations for maintainers.
> 
> Job-level **`ISSUE_NUMBER`** / **`PR_NUMBER`** are set from the dispatch input or the original event, and prompts/post steps use those env vars so manual and automatic runs target the same hardcoded number (not model-controlled). **Skip rules** (maintainer-authored issues, bot PRs) apply only on the automatic triggers; **`workflow_dispatch`** bypasses them so an explicit manual request always runs.
> 
> Header comments note that dispatch requires repo write access while **read-only Claude + structured JSON + secret-pattern gate** behavior is unchanged for either trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e52efe35105a7ba380ec01534e239aee6eefa773. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->