### PR TITLE
ci: re-review on push (update-in-place) + max-turns 8/6 -> 35

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -121,7 +121,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr list:*)"
-            --max-turns 6
+            --max-turns 35
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if the issue is already clear/actionable and needs no comment"},"comment_body":{"type":"string","description":"The triage comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -42,6 +42,15 @@ name: Claude Automated PR Review
 #     on this workflow -- per the action's own docs both can leak
 #     tokens/credentials into public step logs.
 #
+# Re-review on push: `synchronize` re-runs this on every commit pushed to the
+# PR (in addition to `opened`), so a push/review/iterate loop stays current.
+# This multiplies the "no rate limiting" residual risk below by every commit
+# pushed by anyone -- including fork contributors -- not just once per PR.
+# To avoid piling up one comment per push, the posting step below edits the
+# SAME comment in place (found by an invisible `<!-- claude-pr-review:auto -->`
+# marker written by the shell step, never by the model) instead of creating a
+# new one each time.
+#
 # Residual risks not fully closed by the above (see PR description for the
 # full writeup): no volume/rate limiting on how many times this can fire
 # (set a spend alert on the API key); Claude Code's Bash allowlist matching
@@ -61,7 +70,7 @@ name: Claude Automated PR Review
 
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -85,6 +94,7 @@ jobs:
     timeout-minutes: 15
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+      REPO: ${{ github.repository }}
     steps:
       - name: Checkout base branch only (never the untrusted PR head)
         uses: actions/checkout@v6
@@ -156,7 +166,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*)"
-            --max-turns 8
+            --max-turns 35
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if this routine/out-of-scope PR should get no comment at all"},"comment_body":{"type":"string","description":"The review comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)
@@ -173,7 +183,12 @@ jobs:
             exit 0
           fi
 
-          echo "$STRUCTURED_OUTPUT" | jq -r '.comment_body' > review_body.txt
+          # Deterministic marker, not model-controlled -- identifies our own
+          # comment across re-runs so a re-review updates it in place instead
+          # of piling up one comment per push.
+          MARKER="<!-- claude-pr-review:auto -->"
+          echo "$MARKER" > review_body.txt
+          echo "$STRUCTURED_OUTPUT" | jq -r '.comment_body' >> review_body.txt
 
           # Hard, deterministic gate -- independent of anything the model was told.
           # Known secret shapes for what THIS workflow has access to (Anthropic API
@@ -183,4 +198,13 @@ jobs:
             exit 1
           fi
 
-          gh pr comment "$PR_NUMBER" --body-file review_body.txt
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate \
+            -q '.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("<!-- claude-pr-review:auto -->")) | .id' \
+            | tail -n1)
+
+          if [ -n "$EXISTING_ID" ]; then
+            echo "Updating prior automated review comment (id $EXISTING_ID) in place."
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" -X PATCH -f body=@review_body.txt >/dev/null
+          else
+            gh pr comment "$PR_NUMBER" --body-file review_body.txt
+          fi


### PR DESCRIPTION
Brings this repo's Claude review workflows (#520) up to the same spec now used on sibling repos (redisbench-admin, go-ycsb, redis-benchmarks-specification):

- `claude-pr-review.yml` adds `synchronize` to the trigger types so pushing new commits to an open PR re-runs the review -- supports a push/review/iterate loop instead of a one-shot comment at open time. The posting step now finds its own prior comment via a deterministic `<!-- claude-pr-review:auto -->` marker and PATCHes it in place instead of posting a new comment on every push.
- Both workflows raise `--max-turns` to 35 -- a live dry run on a sibling repo hit `error_max_turns` twice (at 8 and 20) before a non-trivial PR's review completed in 21 turns.

Residual risk: `synchronize` multiplies the already-flagged 'anyone can trigger a paid run' risk by every commit pushed to an open PR, including from forks -- worth a spend alert on the Anthropic key if one isn't set yet.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Re-running on every `synchronize` increases Anthropic API usage and fork-triggered runs; posting still goes through the existing secret-pattern gate and read-only Claude step.
> 
> **Overview**
> Aligns the Claude GitHub Actions workflows with sibling repos: **higher turn budget** and **PR reviews that stay current on new pushes**.
> 
> Both `claude-issue-triage.yml` and `claude-pr-review.yml` raise `--max-turns` from **6/8 to 35** so longer reviews/triage runs are less likely to hit `error_max_turns` mid-job.
> 
> `claude-pr-review.yml` now triggers on **`synchronize`** as well as `opened`, so each push to an open PR can re-run the automated review. The post step prepends a fixed `<!-- claude-pr-review:auto -->` marker (shell-written, not model-controlled), looks up an existing `github-actions[bot]` comment with that prefix, and **PATCHes** it instead of posting a new comment each time. Job env adds **`REPO`** for the `gh api` comment lookup/update path. Header comments document the extra API-run frequency from re-review on every commit (including forks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85e3c4521046abc9a74f31ea680b2f6d7908640. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->