### PR TITLE
ci: raise claude review max-turns 35 -> 99

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -121,7 +121,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh pr list:*)"
-            --max-turns 35
+            --max-turns 99
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if the issue is already clear/actionable and needs no comment"},"comment_body":{"type":"string","description":"The triage comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -166,7 +166,7 @@ jobs:
 
           claude_args: |
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*)"
-            --max-turns 35
+            --max-turns 99
             --json-schema '{"type":"object","properties":{"skip_comment":{"type":"boolean","description":"true if this routine/out-of-scope PR should get no comment at all"},"comment_body":{"type":"string","description":"The review comment text, empty string if skip_comment is true"}},"required":["skip_comment","comment_body"]}'
 
       - name: Post comment (only after a deterministic secret-pattern check)


### PR DESCRIPTION
Matches the same bump applied to sibling repos (redisbench-admin, go-ycsb, redis-benchmarks-specification) after redisbench-admin's live push/review/iterate loop hit `error_max_turns` again at 35.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tuning of agent turn limits; no application code, secrets handling, or posting logic changes.
> 
> **Overview**
> Raises the Claude Code action **`--max-turns`** limit from **35** to **99** in both automated workflows: **issue triage** (`claude-issue-triage.yml`) and **PR review** (`claude-pr-review.yml`).
> 
> The bump aligns with sibling repos and avoids runs failing with **`error_max_turns`** when the agent needs more tool rounds (e.g. during push/review/iterate loops on PR review). No other workflow behavior, prompts, or security gates change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09a6d555ede4552fa3e5f79b76bd0129ff96bdc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->