### PR TITLE
ci: pin RLTest fork dependency to a commit SHA instead of a branch name

### DIFF
--- a/tests/test_requirements.txt
+++ b/tests/test_requirements.txt
@@ -1,12 +1,16 @@
 redis>=3.0.0
-# TEMPORARY: pinned to a fork branch that teaches RLTest's ClusterEnv to add
+# TEMPORARY: pinned to a fork commit that teaches RLTest's ClusterEnv to add
 # replica shards to the OSS cluster (CLUSTER MEET + CLUSTER REPLICATE) instead
 # of merely wiring them with --slaveof. Without this, --use-slaves replicas are
 # invisible to cluster gossip and the read-preference matrix cell that
 # exercises OSS-CLUSTER + replicas silently degenerates into a master-only
-# topology. Revert to git+https://github.com/RedisLabsModules/RLTest.git@master
-# once upstream PR https://github.com/RedisLabsModules/RLTest/pull/253 merges.
-git+https://github.com/fcostaoliveira/RLTest.git@fix/cluster-aware-replicas
+# topology. Pinned to a commit SHA rather than the fix/cluster-aware-replicas
+# branch name so a force-push/rename/delete on that branch can't move what's
+# actually installed out from under CI (or a stale local checkout) without a
+# visible diff here. Revert to
+# git+https://github.com/RedisLabsModules/RLTest.git@master once upstream PR
+# https://github.com/RedisLabsModules/RLTest/pull/253 merges.
+git+https://github.com/fcostaoliveira/RLTest.git@4808b5f63f55788c094b111e1adecd00b9716a00
 # pytest + hypothesis power the CLI argument fuzzer (tests/test_cli_fuzz.py,
 # issue #410). The fuzzer is gated by MEMTIER_FUZZ=1 so it's only pulled in
 # on demand; pinning them here keeps the bootstrap reproducible.


### PR DESCRIPTION
## Summary

`tests/test_requirements.txt` points at `git+https://github.com/fcostaoliveira/RLTest.git@fix/cluster-aware-replicas` -- a mutable branch name on a personal fork. A force-push, rename, or deletion of that branch could silently change what every CI cell installs, with no diff anywhere in this repo to show it happened.

Pins to the branch's current commit SHA (`4808b5f6`) instead. No functional change -- same fork, same commit, just addressed immutably from here on.

Split out of PR #526's review thread (raised there across several rounds) so this CI-dependency change can land independently of that feature's review. The broader "should CI depend on a personal fork's continued availability at all" question is tracked separately in #530 -- this PR only closes the mutation/force-push angle, not the availability one.

## Test plan

- [x] `pip install -r tests/test_requirements.txt` installs cleanly at the pinned SHA.
- [x] No other files changed; this is a one-line dependency pin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test dependency pinning only; no runtime or application behavior change.
> 
> **Overview**
> **Pins the temporary RLTest fork** in `tests/test_requirements.txt` from the mutable branch `fix/cluster-aware-replicas` to commit `4808b5f63f55788c094b111e1adecd00b9716a00`. Same fork and same code as before; only the install reference is immutable.
> 
> Comments now explain that SHA pinning prevents a force-push, rename, or branch delete on the fork from changing what CI installs without a visible change in this repo. Upstream revert path (RedisLabsModules/RLTest `master` after PR #253) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 734b45f77f689cb4b11b7e0791be95d1478cc5b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->